### PR TITLE
Create the generator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+; Unix-style newlines
+[*]
+indent_size = 2
+end_of_line = LF
+indent_style = space
+insert_final_newline = true

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules/**

--- a/default/index.js
+++ b/default/index.js
@@ -1,34 +1,97 @@
+var makeBadge = require('./make-badge');
+var parseUrl = require('./parse-git-url');
 var Generator = require('yeoman-generator');
+var gitRemoteOriginUrl = require('git-remote-origin-url');
 
 module.exports = Generator.extend({
   constructor: function(args, opts) {
     Generator.call(this, args, opts);
-    this.pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
-    
-    this.files = [
-      'file.js'
-    ];
+
+    this.configPath = this.destinationPath('.travis.yml');
+    this.readmePath = this.destinationPath('README.md');
   },
 
-  prompting: function () {
-    var done = this.async();
+  initializing: function initializing() {
+    var configExists = this.fs.exists(this.configPath);
+    var readmeExists = this.fs.exists(this.readmePath);
 
-    this.prompt([{
-      type    : 'input',
-      name    : 'name',
-      message : 'What is the name of the file?'
-    }]).then(function(answers) {
-      this.props = answers;
-      done();
-    }.bind(this));
+    if (configExists) {
+      this.abort = true;
+      this.log.error('.travis.yml file already exists, aborting command.');
+      return;
+    }
+
+    if (readmeExists) {
+      var readme = this.fs.read(this.readmePath);
+
+      // checks whether the badge link is in the README already
+      var badgeExists = /\!\[Build Status\]/.test(readme);
+
+      if (badgeExists) {
+        this.skipBadge = true;
+      }
+    } else {
+      this.log('WARNING: README.md not found, Travis badge skipped');
+      this.skipBadge = true;
+    }
   },
-  writing: function () {
-    this.log('Copying file to ' + this.destinationPath(this.props.name + '.js'));
-    
-    this.fs.copyTpl(
-			this.templatePath('file.js'),
-			this.destinationPath(this.props.name + '.js'),
-			this.props
-		);
+
+  prompting: function prompting() {
+    if (this.abort || this.skipBadge) {
+      return;
+    }
+
+    var self = this;
+    var done = self.async();
+
+    gitRemoteOriginUrl()
+      .then(parseUrl, function onError() {
+        return parseUrl('');
+      })
+      .then(self._prompt.bind(self))
+      .then(function(answers) {
+        self.props = answers;
+        done();
+      });
+  },
+
+  writing: function writing() {
+    if (!this.abort) {
+      this._writeTravisConfig();
+      this._writeTravisBadge();
+    }
+  },
+
+  /* private methods */
+  _prompt: function prompt(parsed) {
+    return this.prompt([
+      {
+        type: 'input',
+        name: 'owner',
+        message: 'What is the GitHub owner name?',
+        default: parsed.owner ? parsed.owner : null
+      },
+      {
+        type: 'input',
+        name: 'name',
+        message: 'What is the GitHub repository name?',
+        default: parsed.name ? parsed.name : null
+      }
+    ]);
+  },
+
+  _writeTravisConfig: function writeTravisConfig() {
+    this.log('Writing config file to ' + this.configPath);
+    this.fs.copyTpl(this.templatePath('travis.yml'), this.configPath);
+  },
+
+  _writeTravisBadge: function writeTravisBadge() {
+    if (!this.skipBadge && this.props.owner && this.props.name) {
+      var readme = this.fs.read(this.readmePath);
+      var badge = makeBadge(this.props.owner + '/' + this.props.name);
+
+      this.log('Adding Travis badge markdown to ' + this.readmePath);
+      this.fs.write(this.readmePath, `${badge}\n${readme}`);
+    }
   }
 });

--- a/default/make-badge.js
+++ b/default/make-badge.js
@@ -1,0 +1,3 @@
+module.exports = function makeBadge(fullname) {
+  return `[![Build Status](https://travis-ci.org/${fullname}.png?branch=master)](https://travis-ci.org/${fullname})`;
+};

--- a/default/parse-git-url.js
+++ b/default/parse-git-url.js
@@ -1,0 +1,40 @@
+var url = require('url');
+
+function isEmptyString(val) {
+  return typeof val === 'string' && !val.length;
+}
+
+module.exports = function parseUrl(gitUrl) {
+  var obj = {};
+
+  if (isEmptyString(gitUrl)) {
+    return obj;
+  }
+
+  var parsed = url.parse(gitUrl);
+  if (isEmptyString(parsed.path) || isEmptyString(parsed.pathname)) {
+    return obj;
+  }
+
+  // donejs/donejs-travis.git
+  var collect = function collect(fullname) {
+    var parts = fullname.split('/').filter(Boolean);
+    obj.owner = parts[0];
+    obj.name = parts[1].replace('.git', '');
+  };
+
+  // https://github.com/donejs/donejs-travis.git
+  if (parsed.protocol) {
+    collect(parsed.pathname);
+  } else {
+    // git@github.com:donejs/donejs-travis.git
+    var parts = parsed.pathname.split(':');
+    if (parts.length === 2) {
+      collect(parts[1]);
+    } else {
+      collect(parts[0]);
+    }
+  }
+
+  return obj;
+};

--- a/default/templates/badge
+++ b/default/templates/badge
@@ -1,1 +1,0 @@
-[![Build Status](https://travis-ci.org/<%= fullname %>.png?branch=master)](https://travis-ci.org/<%= fullname %>)

--- a/default/templates/badge
+++ b/default/templates/badge
@@ -1,0 +1,1 @@
+[![Build Status](https://travis-ci.org/<%= fullname %>.png?branch=master)](https://travis-ci.org/<%= fullname %>)

--- a/default/templates/file.js
+++ b/default/templates/file.js
@@ -1,3 +1,0 @@
-export default function() {
-  return 'This is a file from the donejs-travis DoneJS generator';
-}

--- a/default/templates/travis.yml
+++ b/default/templates/travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js: node
+addons:
+  firefox: "latest"
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "donejs-travis",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -47,7 +47,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "balanced-match": {
@@ -255,6 +255,11 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -333,9 +338,9 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "editions": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "ejs": {
       "version": "2.5.7",
@@ -447,6 +452,40 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
+    "gh-got": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+      "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+      "requires": {
+        "got": "6.7.1",
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+      "requires": {
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
+      }
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+      "requires": {
+        "ini": "1.3.5"
+      }
+    },
+    "github-username": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+      "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+      "requires": {
+        "gh-got": "5.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -479,6 +518,24 @@
         }
       }
     },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -489,7 +546,7 @@
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "growl": {
@@ -576,6 +633,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "inquirer": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
@@ -587,7 +649,7 @@
         "cli-width": "2.2.0",
         "external-editor": "1.1.1",
         "figures": "1.7.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.6",
         "pinkie-promise": "2.0.1",
         "run-async": "2.3.0",
@@ -678,7 +740,7 @@
       "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
       "requires": {
         "binaryextensions": "2.1.1",
-        "editions": "1.3.3",
+        "editions": "1.3.4",
         "textextensions": "2.2.0"
       }
     },
@@ -736,6 +798,17 @@
         }
       }
     },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -746,9 +819,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -833,9 +906,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
@@ -1042,6 +1115,14 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1072,6 +1153,14 @@
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
+      }
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "requires": {
+        "pify": "2.3.0"
       }
     },
     "pify": {
@@ -1126,6 +1215,25 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       }
     },
     "readable-stream": {
@@ -1283,7 +1391,7 @@
         "path-to-regexp": "1.7.0",
         "samsam": "1.3.0",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.7"
+        "type-detect": "4.0.8"
       },
       "dependencies": {
         "diff": {
@@ -1437,9 +1545,9 @@
       "dev": true
     },
     "type-detect": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
-      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {
@@ -1592,7 +1700,7 @@
         "globby": "4.1.0",
         "grouped-queue": "0.3.3",
         "inquirer": "1.2.3",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "log-symbols": "1.0.2",
         "mem-fs": "1.1.3",
         "text-table": "0.2.0",
@@ -1650,7 +1758,7 @@
         "github-username": "3.0.0",
         "glob": "7.1.2",
         "istextorbinary": "2.2.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mem-fs-editor": "3.0.2",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
@@ -1666,94 +1774,6 @@
         "through2": "2.0.3",
         "user-home": "2.0.0",
         "yeoman-environment": "1.6.6"
-      },
-      "dependencies": {
-        "dateformat": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
-        },
-        "gh-got": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
-          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
-          "requires": {
-            "got": "6.7.1",
-            "is-plain-obj": "1.1.0"
-          }
-        },
-        "github-username": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
-          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
-          "requires": {
-            "gh-got": "5.0.0"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        }
       }
     },
     "yeoman-test": {
@@ -1763,7 +1783,7 @@
       "dev": true,
       "requires": {
         "inquirer": "3.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2",
@@ -1860,7 +1880,7 @@
             "cli-width": "2.2.0",
             "external-editor": "2.1.0",
             "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rx-lite": "4.0.8",
@@ -1897,7 +1917,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "restore-cursor": {
@@ -1967,7 +1987,7 @@
             "grouped-queue": "0.3.3",
             "inquirer": "3.3.0",
             "is-scoped": "1.0.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "log-symbols": "2.2.0",
             "mem-fs": "1.1.3",
             "text-table": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "donejs-travis",
   "version": "0.0.1",
-  "description": "",
+  "description": "A Yeoman generator to setup Travis in your DoneJS application",
   "homepage": "",
   "author": {
-    "name": "",
-    "email": "",
-    "url": ""
+    "name": "Bitovi",
+    "email": "contact@bitovi.com",
+    "url": "http://bitovi.com/"
   },
   "main": "lib/",
   "scripts": {
@@ -19,7 +19,7 @@
     "release:major": "npm version major && npm publish"
   },
   "keywords": [
-    "",
+    "donejs",
     "donejs-generator"
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib/",
   "scripts": {
     "test": "npm run jshint && npm run mocha",
-    "jshint": "jshint test/. default/index.js --config",
+    "jshint": "jshint . --config",
     "mocha": "mocha test/ --timeout 120000",
     "publish": "git push origin --tags && git push origin",
     "release:patch": "npm version patch && npm publish",
@@ -24,6 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "git-remote-origin-url": "^2.0.0",
     "lodash": "^4.17.4",
     "yeoman-generator": "^1.1.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,18 +1,87 @@
+var fs = require('fs');
 var path = require('path');
 var helpers = require('yeoman-test');
 var assert = require('yeoman-assert');
 
 describe('donejs-travis', function() {
-  before(function(done) {
-    helpers.run(path.join(__dirname, '../default'))
-      .inTmpDir()
-      .withPrompts({
-        name: 'testing'
-      }).on('end', done);
+  // user following the guide
+  describe('travis.yml does not exist but README.md does', function() {
+    before(function(done) {
+      helpers
+        .run(path.join(__dirname, '..', 'default'))
+        .withPrompts({ owner: 'owner', name: 'place-my-order' })
+        .inTmpDir(function(dir) {
+          fs.copyFileSync(
+            path.join(__dirname, 'readme_fixture.md'),
+            path.join(dir, 'README.md')
+          );
+        })
+        .on('end', done);
+    });
+
+    it('should write config file', function() {
+      assert.fileContent('.travis.yml', /language: node_js/);
+    });
+
+    it('should add travis badge to readme', function() {
+      assert.fileContent('README.md', /\!\[Build Status\]/);
+    });
   });
 
-  it('should write testing.js file', function() {
-    assert.file(['testing.js']);
-    assert.fileContent('testing.js', /This is a file from the donejs-travis DoneJS generator/);
+  describe('no travis.yml, existing README.md but empty options', function() {
+    before(function(done) {
+      helpers
+        .run(path.join(__dirname, '..', 'default'))
+        .inTmpDir(function(dir) {
+          fs.copyFileSync(
+            path.join(__dirname, 'readme_fixture.md'),
+            path.join(dir, 'README.md')
+          );
+        })
+        .on('end', done);
+    });
+
+    it('should write config file', function() {
+      assert.fileContent('.travis.yml', /language: node_js/);
+    });
+
+    it('does not add the badge with missing data', function() {
+      assert.noFileContent('README.md', /\!\[Build Status\]/);
+    });
+  });
+
+  describe('no travis.yml, no README.md', function() {
+    before(function(done) {
+      helpers
+        .run(path.join(__dirname, '..', 'default'))
+        .inTmpDir()
+        .on('end', done);
+    });
+
+    it('should write config file', function() {
+      assert.fileContent('.travis.yml', /language: node_js/);
+    });
+
+    it('skips the badge', function() {
+      assert.noFile('README.md');
+    });
+  });
+
+  describe('travis.yml file exists already', function() {
+    before(function(done) {
+      helpers
+        .run(path.join(__dirname, '..', 'default'))
+        .inTmpDir(function(dir) {
+          fs.copyFileSync(
+            path.join(__dirname, 'travis_fixture.yml'),
+            path.join(dir, '.travis.yml')
+          );
+        })
+        .on('end', done);
+    });
+
+    it('should not overwrite file', function() {
+      assert.fileContent('.travis.yml', /language: ruby/);
+    });
   });
 });

--- a/test/parse-url.js
+++ b/test/parse-url.js
@@ -1,0 +1,27 @@
+var assert = require('assert');
+var parseUrl = require('../default/parse-git-url');
+
+describe('parseGitUrl', function() {
+  it('with empty string', function() {
+    var parsed = parseUrl('');
+    assert.deepEqual(parsed, {}, 'returns empty object');
+  });
+
+  it('works with local urls', function() {
+    var parsed = parseUrl('/srv/project.git');
+    assert.equal(parsed.owner, 'srv');
+    assert.equal(parsed.name, 'project');
+  });
+
+  it('works with github http urls', function() {
+    var parsed = parseUrl('https://github.com/donejs/donejs-travis.git');
+    assert.equal(parsed.owner, 'donejs');
+    assert.equal(parsed.name, 'donejs-travis');
+  });
+
+  it('works with github ssh urls', function() {
+    var parsed = parseUrl('git@github.com:donejs/donejs-travis.git');
+    assert.equal(parsed.owner, 'donejs');
+    assert.equal(parsed.name, 'donejs-travis');
+  });
+});

--- a/test/readme_fixture.md
+++ b/test/readme_fixture.md
@@ -1,0 +1,1 @@
+# place-my-order

--- a/test/travis_fixture.yml
+++ b/test/travis_fixture.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.2
+  - jruby
+  - 2.0.0-p247


### PR DESCRIPTION
I have to add more tests, but I have some questions:

a) **About the badge**, currently the generator asks the user to type the repository full name.... The issue mentions asking for the username instead (and try to retrieve it from the git remote) .... I noticed testing that since the repo has not been pushed to github (people following the guide) there won't be any git data to retrieve the user from. We could:

  1) Just remove the badge feature thing which simplifies a lot the code
  2) Maybe try to retrieve the github username by getting the email from the git config and then using something like this https://github.com/sindresorhus/github-username (the app name we get from the package json)
    2.1) the prompt would ask for each thing individually, instead of a single question like now.

a.1) I noticed that prepending the badge to the README causes yeoman to trigger the conflict resolution prompt, are we ok with this? 

a.2) is the warning ok when we can't find README.md, as opposed to aborting the whole thing like when `.travis.yml` is found?
            
b) We could **throw an error if `travis.yml` exists already**, but not sure if it's a good idea, I made it so a flag `this.abort` and the other methods in the generator just return early. Do we have a preferred approach here?



     
